### PR TITLE
GitPod config with Dockerfile

### DIFF
--- a/.gitpod-base.Dockerfile
+++ b/.gitpod-base.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+COPY .scripts .scripts
+RUN bash ./.scripts/setup.bash --dependencies-only && \
+    bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java 20.0.1-open < /dev/null"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,37 @@
+image:
+  file: .gitpod-base.Dockerfile
+
+## Example is handled separately in GitPod for faster initialisation.
+tasks:
+  - name: Setup LF
+    init: >
+      case "$RELEASE_BUILD" in
+        'dev') 
+            git clone https://github.com/lf-lang/lingua-franca.git --branch master --depth 1
+            cd lingua-franca
+            git submodule update --init --recursive
+            ./gradlew buildAll
+            cd .. 
+        ;;
+        *) 
+            # GitPod's python3 is not /usr/bin/python3......
+            python3 ./.scripts/get-lf-executable $RELEASE_BUILD
+            mkdir lingua-franca
+            # While what we have here is tar.gz, lf release bot appear to have a bug and did not gunzip it.
+            # Therefore `tar -xzf` will fail but `tar -xf` will work.
+            # Here, we ignore the actual build name (the original name of the file and the original first directory). 
+            tar -xf lf.tar.gz -C lingua-franca --strip-components 1
+            rm lf.tar.gz
+        ;;
+      esac && exit
+  - name: Setup Example
+    init: if [ -z "$NO_EXAMPLE" ]; then git clone https://github.com/lf-lang/examples-lingua-franca.git examples --branch main; fi
+    command: exit
+## Dirty hack, https://github.com/gitpod-io/gitpod/issues/9275#issuecomment-1098275529
+  - name: Setup env
+    before: >
+      printf 'export PATH="%s:$PATH"; export LF_PATH="%s";\n' "${GITPOD_REPO_ROOT}/lingua-franca/bin" "${GITPOD_REPO_ROOT}/lingua-franca/" >> $HOME/.bashrc && exit
+
+vscode: 
+  extensions:
+    - lf-lang.vscode-lingua-franca

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 image:
   file: .gitpod-base.Dockerfile
 
-## Example is handled separately in GitPod for faster initialisation.
+## Example is handled separately in GitPod for faster initialization.
 tasks:
   - name: Setup LF
     init: >

--- a/.scripts/setup.bash
+++ b/.scripts/setup.bash
@@ -25,9 +25,11 @@ if [ -n "$DISTRIB_CODENAME" ]; then
     echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${DISTRIB_CODENAME} main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
     sudo apt update && sudo apt install --assume-yes cmake
 fi
+## Setup Java
+sudo apt install --assume-yes openjdk-17-jre openjdk-17-jdk
 ## Setup Python
 sudo apt install --assume-yes python3 python3-dev python3-pip
-python3 -m pip install --exists-action i setuptools
+python3 -m pip install --exists-action i requests setuptools 
 ## Setup Typescript
 npm install -g typescript
 ## Setup Rust
@@ -35,15 +37,23 @@ sudo apt install --assume-yes rustc
 
 RELEASE_BUILD="nightly"
 EXAMPLE=1
+DEPENDENCIES_ONLY=0
 
 for arg in "$@"; do
     shift
     case "$arg" in
         'dev') RELEASE_BUILD="dev";;
         'stable') RELEASE_BUILD="stable";;
-        '--no-example') EXAMPLE=0
+        '--no-example') EXAMPLE=0;;
+        '--dependencies-only') DEPENDENCIES_ONLY=1
     esac
 done
+
+# With GitPod, we use .gitpod.yml to set up LF runtime and examples; this allows faster speed.
+# Also good for people who want to do everything themselves!
+if [ $DEPENDENCIES_ONLY == 1 ]; then
+    exit 0
+fi
 
 # Use case here for maximum flexibility if we were to change later
 case "$RELEASE_BUILD" in
@@ -55,7 +65,7 @@ case "$RELEASE_BUILD" in
         cd .. 
     ;;
     *) 
-        ./.scripts/get-lf-executable $RELEASE_BUILD
+        python3 ./.scripts/get-lf-executable $RELEASE_BUILD
         mkdir lingua-franca
         # While what we have here is tar.gz, lf release bot appear to have a bug and did not gunzip it.
         # Therefore `tar -xzf` will fail but `tar -xf` will work.


### PR DESCRIPTION
Current configuration with .gitpod.yml requires the user to wait a while after gitpod workspace indicates "ready" which is not good according to @lhstrh. This change allows gitpod to not show stuff before time-consuming configurations are completed. This is also a crucial step towards building a docker image that supports LF development.

To test: https://gitpod.io/new/#https://github.com/axmmisaka/lingua-franca-playground/tree/gitpod-docker

or https://gitpod.io/new/#imagebuild/https://github.com/axmmisaka/lingua-franca-playground/tree/gitpod-docker
to trigger force rebuild

(Building image takes looooooooooooooong, let's see if we can prebuild image)